### PR TITLE
Manage Address property from Google User Provided Data native GTM variable

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -549,7 +549,7 @@ event.user_data.em = (eventData.user_data != null) ? eventData.user_data.email_a
 event.user_data.ph = (eventData.user_data != null) ? eventData.user_data.phone_number || eventData.user_data.sha256_phone_number : undefined;
 
 // ADDRESS DATA
-const addressData = (eventData.user_data != null && eventData.user_data.address != null) ? eventData.user_data.address : {};
+const addressData = (eventData.user_data != null && eventData.user_data.address != null) ? (eventData.user_data.address[0] != null ? eventData.user_data.address[0] : eventData.user_data.address) : {};
 event.user_data.ge = addressData.gender;
 event.user_data.fn = addressData.first_name || addressData.sha256_first_name;
 event.user_data.ln = addressData.last_name || addressData.sha256_last_name;


### PR DESCRIPTION
The native variable "User Provided Data" send data in a specific format that have to be handled.

In fact, user_data sent by the variable is formatted like :
{
  email: "xxx",
  phone_number: "xxx",
  address: {
    0: {
      first_name: "xxx",
      last_name: "xxx",
      city: "xxx",
      country: "xxx",
      postal_code: "xxx"
    }
  },
}

But, to not break existing configurations, the format below is also available :
{
  email: "xxx",
  phone_number: "xxx",
  address: {
      first_name: "xxx",
      last_name: "xxx",
      city: "xxx",
      country: "xxx",
      postal_code: "xxx"
  },
}
