### PR TITLE
Change pixel query parameters

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.addingwell.com"
 documentation: "https://docs.addingwell.com/meta-capi/benefits"
 versions:
+  - sha: 554fa150e064507a14beff719af8aad0f4191cb7
+    changeNotes: Change pixel query parameters
   - sha: 8c5927f972863bea38bed501c18ef36c3dd74d89
     changeNotes: Add documentation + fixes
   - sha: c1eef1b2081f58e826123fd6d3fe9437b5867665

--- a/template.tpl
+++ b/template.tpl
@@ -726,6 +726,7 @@ sendHttpRequest(graphEndpoint, (statusCode, headers, body) => {
 
       let urlParams = [
         ['id', enc(data.pixelId)],
+        ['ev', event.event_name],
         ['dl', eventData.page_location],
         ['rl', eventData.page_referrer],
         ['sw', sw],
@@ -769,9 +770,9 @@ sendHttpRequest(graphEndpoint, (statusCode, headers, body) => {
         });
       }
 
-      let params = "?ev=" + event.event_name + '&' + urlParams.filter((v) => v[1]).map((v) => v[0] + '=' + encodeUriComponent(v[1].toString())).join('&');
+      let params = "?" + urlParams.filter((v) => v[1]).map((v) => v[0] + '=' + encodeUriComponent(v[1].toString())).join('&');
 
-      sendPixelFromBrowser('https://www.facebook.com/tr/' + params);
+      sendPixelFromBrowser('https://www.facebook.com/tr' + params);
     }
 
     data.gtmOnSuccess();


### PR DESCRIPTION
Change ordering of query parameters by placing "id" before "ev", and remove stray slashes after /tr on the request to prevent malformed events such as PageView?ev=PageView from being sent.